### PR TITLE
Feature/start page

### DIFF
--- a/src/components/color/ColorSelectBox.tsx
+++ b/src/components/color/ColorSelectBox.tsx
@@ -11,9 +11,7 @@ const ColorSelectBox = ({
   playerColor: ColorOption['value'];
 }) => {
   const { updatePlayerColor, updateRandomPlayerColor } = playerStore((state) => state);
-  const unAvailableColors = playerStore((state) => state.playerNames).map((p) => p.color);
-
-  console.log(unAvailableColors);
+  const unAvailableColors = playerStore((state) => state.playerInfos).map((p) => p.playerColor);
 
   return (
     <div className="color-container">

--- a/src/pages/game/Game.tsx
+++ b/src/pages/game/Game.tsx
@@ -1,11 +1,9 @@
 import Dice from './Dice';
 import GameControl from './GameControl';
 import MiniMap from './MiniMap';
-import Lucky from './Lucky';
 import PlayerInfo from './PlayerInfo';
 import { BOARD_DATA } from '../../utils/mapInfo';
 import gameStore from '../../stores/gameStore';
-import { useEffect } from 'react';
 
 const Game = () => {
   const { players, gameName } = gameStore((state) => state);

--- a/src/pages/game/PlayerInfo.tsx
+++ b/src/pages/game/PlayerInfo.tsx
@@ -1,3 +1,4 @@
+import playerStore from '../../stores/playerStore';
 import Lucky from './Lucky';
 import Player from './Player';
 
@@ -85,13 +86,15 @@ const players: PlayerType[] = [
 ];
 
 const PlayerInfo = () => {
+  const playerInfos = playerStore((state) => state.playerInfos);
+  console.log(playerInfos);
   return (
     <>
       <Lucky />
       <section className="player-container console-container">
         <h3>플레이어 정보</h3>
         <section className="players">
-          {players.map((player) => (
+          {playerInfos.map((player) => (
             <Player player={player} key={`${player.id}-${player.name}`} />
           ))}
         </section>

--- a/src/pages/game/hooks/useRollDice.ts
+++ b/src/pages/game/hooks/useRollDice.ts
@@ -1,4 +1,6 @@
 import { Dispatch, SetStateAction, useState } from 'react';
+import playerStore from '../../../stores/playerStore';
+import useUpdatePlayerPosition from './useUpdatePlayerPosition';
 
 interface DicesType {
   val1: number;
@@ -12,6 +14,7 @@ const useRollDice = () => {
   const [dice1, setDice1] = useState(() => pickNumber());
   const [dice2, setDice2] = useState(() => pickNumber());
   const [isRolling, setisRolling] = useState(false);
+  const { updatePosition } = useUpdatePlayerPosition();
 
   const dices: DicesType = {
     val1: dice1,
@@ -28,6 +31,9 @@ const useRollDice = () => {
     setTimeout(() => {
       clearInterval(intervalId);
       setisRolling(false);
+      setTimeout(() => {
+        updatePosition({ diceNum: dices.val1 + dices.val2, isDouble: dices.val1 === dices.val2 });
+      }, 0);
     }, 1000);
   };
 

--- a/src/pages/game/hooks/useUpdatePlayerPosition.ts
+++ b/src/pages/game/hooks/useUpdatePlayerPosition.ts
@@ -1,0 +1,17 @@
+import playerStore from '../../../stores/playerStore';
+
+const useUpdatePlayerPosition = () => {
+  const { getNowTurnId, updatePlayer } = playerStore();
+  const nowId = getNowTurnId();
+  const updatePosition = ({ diceNum, isDouble }: { diceNum: number; isDouble: boolean }) => {
+    updatePlayer(nowId, ['position', 'number'], diceNum);
+    if (isDouble) {
+      updatePlayer(nowId, ['isDouble'], true);
+      updatePlayer(nowId, ['doubleTurnLeft'], 1);
+    }
+  };
+  // updatePlayer(nowId, { player: { position: { number: diceNum } } });
+  return { updatePosition };
+};
+
+export default useUpdatePlayerPosition;

--- a/src/pages/start/Players.tsx
+++ b/src/pages/start/Players.tsx
@@ -3,21 +3,19 @@ import playerStore from '../../stores/playerStore';
 import ColorSelectBox from '../../components/color/ColorSelectBox';
 
 const Players = () => {
-  const { updatePlayerName, updateRandomPlayerName, playerNames } = playerStore();
+  const { updatePlayerName, updateRandomPlayerName, playerInfos } = playerStore();
 
-  console.log(playerNames);
-
-  return playerNames.map(({ id, color }, index) => (
-    <section className="players-container" key={`${id}-${color}`}>
+  return playerInfos.map(({ id, playerColor }, index) => (
+    <section className="players-container" key={`${id}-${playerColor}`}>
       <InputWithRandomButton
-        value={playerNames[index].name}
-        label={`플레이어 ${index + 1} 이름 : ${playerNames[index]?.name || `플레이어 ${index + 1}`}`}
+        value={playerInfos[index].name}
+        label={`플레이어 ${index + 1} 이름 : ${playerInfos[index]?.name || `플레이어 ${index + 1}`}`}
         key={`player-${index + 1}`}
         placeholder={`플레이어 ${index + 1}의 이름을 입력해주세요`}
         onClickRandom={() => updateRandomPlayerName(id)}
         onChangeFn={(value) => updatePlayerName(index, value)}
       />
-      <ColorSelectBox playerId={id} playerColor={color} />
+      <ColorSelectBox playerId={id} playerColor={playerColor} />
     </section>
   ));
 };

--- a/src/pages/start/SelectElem.tsx
+++ b/src/pages/start/SelectElem.tsx
@@ -1,7 +1,7 @@
 import playerStore from '../../stores/playerStore';
 
 const SelectElem = () => {
-  const { setPlayerNumber, setPlayerInit } = playerStore((state) => state);
+  const { setPlayerNumber, updatePlayerNumber } = playerStore((state) => state);
 
   return Array(5)
     .fill(undefined)
@@ -10,7 +10,7 @@ const SelectElem = () => {
         className="select-elem"
         onClick={() => {
           setPlayerNumber(index + 2);
-          setPlayerInit(index + 2);
+          updatePlayerNumber(index + 2);
         }}
         key={`elem-${index + 1}`}
       >

--- a/src/pages/start/Start.tsx
+++ b/src/pages/start/Start.tsx
@@ -15,7 +15,7 @@ const Start = () => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState<OpenType>(false);
   const [modal, setModal] = useState(false);
-  const { updateEmptyName, playerNames, setPlayerInit } = playerStore();
+  const { updateEmptyName, playerInfos, setPlayerInit } = playerStore();
   const {
     setGameName,
     updateRandomGameName,
@@ -72,7 +72,7 @@ const Start = () => {
             navigate('/game');
           }}
         >
-          <StartModal gameName={gameName} playerNames={playerNames} />
+          <StartModal gameName={gameName} playerInfos={playerInfos} />
         </ConfirmModal>
       )}
     </>

--- a/src/pages/start/Start.tsx
+++ b/src/pages/start/Start.tsx
@@ -15,7 +15,7 @@ const Start = () => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState<OpenType>(false);
   const [modal, setModal] = useState(false);
-  const { updateEmptyName, playerInfos, setPlayerInit } = playerStore();
+  const { updateEmptyName, playerInfos, setPlayerInit, startTurn } = playerStore();
   const {
     setGameName,
     updateRandomGameName,
@@ -68,7 +68,7 @@ const Start = () => {
           setModal={setModal}
           onConfirm={() => {
             startGame();
-            loadGame();
+
             navigate('/game');
           }}
         >

--- a/src/pages/start/Start.tsx
+++ b/src/pages/start/Start.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import InputWithRandomButton from '../../components/input/InputWithRandomButton';
 import { useNavigate } from 'react-router-dom';
 import Players from './Players';
@@ -15,9 +15,21 @@ const Start = () => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState<OpenType>(false);
   const [modal, setModal] = useState(false);
-  const { updateEmptyName, playerNames } = playerStore();
-  const { setGameName, updateRandomGameName, updateEmptyGameName, gameName, startGame, loadGame } =
-    gameStore();
+  const { updateEmptyName, playerNames, setPlayerInit } = playerStore();
+  const {
+    setGameName,
+    updateRandomGameName,
+    updateEmptyGameName,
+    gameName,
+    startGame,
+    resetGame,
+    loadGame,
+  } = gameStore();
+
+  useEffect(() => {
+    resetGame();
+    setPlayerInit();
+  }, []);
 
   return (
     <>

--- a/src/pages/start/StartModal.tsx
+++ b/src/pages/start/StartModal.tsx
@@ -3,10 +3,10 @@ import { PlayerNamesType } from '../../stores/playerStore';
 
 interface Props {
   gameName: GameState['gameName'];
-  playerNames: PlayerNamesType[];
+  playerInfos: PlayerNamesType[];
 }
 
-const StartModal = ({ gameName, playerNames }: Props) => {
+const StartModal = ({ gameName, playerInfos }: Props) => {
   return (
     <div>
       <section className="container">
@@ -16,14 +16,14 @@ const StartModal = ({ gameName, playerNames }: Props) => {
           <div className="m-players-container">
             <div className="player-num">
               <div>플레이어 수 : </div>
-              <div>{playerNames.length}명</div>
+              <div>{playerInfos.length}명</div>
             </div>
-            {playerNames.map((player, index) => (
+            {playerInfos.map((player, index) => (
               <div className="players" key={`${player.id}-${player.name}`}>
                 <div className="p-label">
                   player {index + 1} : {player.name}
                 </div>
-                <div className="p-color" style={{ backgroundColor: player.color }}></div>
+                <div className="p-color" style={{ backgroundColor: player.playerColor }}></div>
               </div>
             ))}
           </div>

--- a/src/stores/gameLogic.ts
+++ b/src/stores/gameLogic.ts
@@ -7,19 +7,21 @@ import {
   UseStore,
   del as delFromDB,
 } from 'idb-keyval';
+import { PlayerState } from './playerStore';
+import { StoreApi } from 'zustand';
 
 const startGameService = async (
   setState: (state: Partial<GameState>) => void,
   getState: () => GameState,
   options: {
     gameName: string;
-    playerStore: any;
+    playerStore: StoreApi<PlayerState>;
     mainStore: any;
   },
 ) => {
   const { gameName } = getState();
   const newStore = createStore(`${gameName}-db`, `${gameName}-store`);
-  const players = options.playerStore.getState().playerNames;
+  const players = options.playerStore.getState().playerInfos;
 
   const gameData: GameData = {
     gameName,
@@ -71,6 +73,14 @@ const loadGameService = async (
   }
 };
 
+// const updateGameService = (
+//   setState: (state: Partial<GameState>) => void,
+//   getState: () => GameState,
+//   options: {
+//     playerStore: any;
+//   },
+// ) => {};
+
 const customStorage = (mainStore: UseStore) => ({
   getItem: async (name: IDBValidKey) => {
     try {
@@ -96,4 +106,4 @@ const customStorage = (mainStore: UseStore) => ({
   },
 });
 
-export { startGameService, loadGameService, customStorage };
+export { startGameService, loadGameService, updateGameService, customStorage };

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -22,6 +22,7 @@ export interface GameState {
   startGame: (value?: boolean) => Promise<void>;
   loadGame: () => Promise<GameData | null | undefined>;
   endGame: (value?: boolean) => void;
+  resetGame: () => void;
   deleteGame: (name: string) => Promise<void>;
   createNewStore: (name: string) => Promise<UseStore>;
 }
@@ -89,6 +90,10 @@ const gameStore = create<GameState>()(
           gameList: state.gameList.filter((gameName) => gameName !== name),
         }));
         // TODO: 해당 게임의 스토어 삭제 로직 추가
+      },
+
+      resetGame: () => {
+        setState({ gameName: '', players: [] });
       },
 
       endGame: (value) => setState({ gameState: value ?? false }),

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -5,7 +5,7 @@ import { generateRandomGameName } from '../utils/sessionNaming';
 import playerStore, { PlayerNamesType } from './playerStore';
 import dayjs from 'dayjs';
 import { createStore, UseStore } from 'idb-keyval';
-import { customStorage, loadGameService, startGameService } from './gameLogic';
+import { customStorage, loadGameService, startGameService, updateGameService } from './gameLogic';
 
 export interface GameState {
   gameName: string;
@@ -83,6 +83,14 @@ const gameStore = create<GameState>()(
         const result = await loadGameService(setState, getState, { mainStore });
         return result;
       },
+
+      // updatePlayer: async (id, value) => {
+      //   const playerInfo = playerStore
+      //   const result = await updateGameService(setState, getState, {
+      //     playerStore,
+      //   });
+      //   return result;
+      // },
 
       deleteGame: async (name: string) => {
         // 게임 목록에서 제거

--- a/src/stores/playerLogic.ts
+++ b/src/stores/playerLogic.ts
@@ -1,38 +1,77 @@
-import { ColorOption, colorOptions } from '../constants/colors';
+import { ColorOption, colorOptions, ValueLabel } from '../constants/colors';
+import { BOARD_DATA } from '../utils/mapInfo';
 import { getRandomElement } from '../utils/utils';
 import { PlayerNamesType, PlayerState } from './playerStore';
 import { v4 as uuid } from 'uuid';
 
-const getAvailableColors = (usedColors: PlayerNamesType['color'][]): ColorOption['value'][] => {
+//선택 가능한 색상
+const getAvailableColors = (
+  usedColors: PlayerNamesType['playerColor'][],
+): ColorOption['value'][] => {
   return colorOptions
     .filter((color) => !usedColors.includes(color.value))
     .map((color) => color.value);
 };
 
-const getPlayerInitialize = ({ number, state }: { number: number; state: PlayerState }) => {
-  const currentPlayers = [...state.playerNames];
-  if (currentPlayers.length > number) {
-    return currentPlayers.slice(0, number);
-  }
+//나머지 색상끼리의 랜덤
+const currentPlayersColor = (state: PlayerState) => {
+  const currentPlayers = [...state.playerInfos];
+  return currentPlayers.map((p) => p.playerColor);
+};
 
-  const playersToAdd = number - state.playerNames.length;
-  const available = getAvailableColors(currentPlayers.map((p) => p.color));
-  const selectedColors = Array(playersToAdd)
+//숫자만큼 랜덤 컬러 가져오기
+const getRandomColors = ({ number, state }: { number: number; state?: PlayerState }) => {
+  const availableColors = !state
+    ? colorOptions.map((color) => color.value)
+    : getAvailableColors(currentPlayersColor(state));
+
+  const randomColors = Array(number)
     .fill(null)
     .reduce<ColorOption['value'][]>((acc) => {
-      const remainingColors = available.filter((color) => !acc.includes(color));
+      const remainingColors = availableColors.filter((color) => !acc.includes(color));
       if (remainingColors.length === 0) return acc;
       acc.push(getRandomElement(remainingColors));
       return acc;
     }, []);
 
-  const newToAddedInit = selectedColors.map((color) => ({
-    id: uuid(),
-    name: '',
-    color,
-  }));
+  return randomColors;
+};
+
+export const playerInitObj = (color: ValueLabel) => ({
+  id: uuid(),
+  name: '',
+  property: undefined,
+  luckyKeys: undefined,
+  cash: 200000,
+  position: {
+    name: BOARD_DATA.top[0].name,
+    number: BOARD_DATA.top[0].id,
+  },
+  isInIsland: false,
+  islandTurnLeft: 0,
+  playerColor: color,
+  isCurrentTurn: false,
+});
+
+const getPlayerInitialize = ({ number, state }: { number: number; state?: PlayerState }) => {
+  const randomColors = getRandomColors({ number, state });
+  const newToAddedInit = randomColors?.map((color) => playerInitObj(color));
+  return newToAddedInit;
+};
+
+const getUpdatedPlayerInit = ({ number, state }: { number: number; state: PlayerState }) => {
+  //플레이어 수가 줄어든다면 맨처음부터 자르기
+  const currentPlayers = [...state.playerInfos];
+  if (currentPlayers.length > number) {
+    return currentPlayers.slice(0, number);
+  }
+
+  //새로 추가할 initObj
+  const needObjNum = number - currentPlayers.length;
+  const randomColors = getRandomColors({ number: needObjNum, state });
+  const newToAddedInit = randomColors?.map((color) => playerInitObj(color));
 
   return [...currentPlayers, ...newToAddedInit];
 };
 
-export { getAvailableColors, getPlayerInitialize };
+export { getAvailableColors, getPlayerInitialize, getUpdatedPlayerInit, getRandomColors };

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -1,94 +1,101 @@
 import { create } from 'zustand';
-// import { persist } from 'zustand/middleware';
-import { v4 as uuid } from 'uuid';
 import { ColorOption, colorOptions } from '../constants/colors';
 import { generateRandomPlayerName } from '../utils/playerNaming';
-import { getRandomElement } from '../utils/utils';
-import { getAvailableColors, getPlayerInitialize } from './playerLogic';
+import { getPlayerInitialize, getRandomColors, getUpdatedPlayerInit } from './playerLogic';
 
 export interface PlayerNamesType {
   id: string;
   name: string;
-  color: ColorOption['value'];
+  property?: {
+    propertyId: string;
+    name: string;
+    buildings: {
+      villa: boolean;
+      building: boolean;
+      hotel: boolean;
+    }[];
+  }[];
+  luckyKeys?: {
+    name: string;
+  }[];
+  cash: number;
+  position: {
+    name: string;
+    number: number;
+  };
+  isInIsland: boolean;
+  islandTurnLeft: number;
+  playerColor: ColorOption['value'];
+  isCurrentTurn: boolean;
 }
 
 export interface PlayerState {
   playerNumber: number;
-  playerNames: PlayerNamesType[];
+  playerInfos: PlayerNamesType[];
   setPlayerNumber: (number: PlayerState['playerNumber']) => void;
   setPlayerInit: () => void;
   updatePlayerNumber: (number: PlayerState['playerNumber']) => void;
   updatePlayerName: (index: number, state: PlayerNamesType['name']) => void;
   updateRandomPlayerName: (playerId: PlayerNamesType['id']) => void;
   updateEmptyName: () => void;
-  updatePlayerColor: (index: PlayerNamesType['id'], state: PlayerNamesType['color']) => void;
+  updatePlayerColor: (index: PlayerNamesType['id'], state: PlayerNamesType['playerColor']) => void;
+  // up9datePlayerInfo: (id: PlayerNamesType['id'] value: Pick<PlayerNamesType>) => void;
   updateRandomPlayerColor: (playerId: PlayerNamesType['id']) => void;
 }
 
 const playerStore = create<PlayerState>((set) => ({
   playerNumber: 2,
-  playerNames: Array(2)
-    .fill(null)
-    .map((_, index) => ({
-      id: uuid(),
-      name: '',
-      color: colorOptions[index].value,
-    })),
+  playerInfos: getPlayerInitialize({ number: 2 }),
   setPlayerNumber: (number: PlayerState['playerNumber']) =>
     set(() => ({
       playerNumber: number,
     })),
   setPlayerInit: () =>
-    set(() => ({
-      playerNames: Array(2)
-        .fill(null)
-        .map((_, index) => ({
-          id: uuid(),
-          name: '',
-          color: colorOptions[index].value,
-        })),
+    set((state) => ({
+      playerInfos: getPlayerInitialize({ number: 2, state: state }),
     })),
   updatePlayerNumber: (number) =>
     set((state: PlayerState) => ({
       ...state,
-      playerNames: getPlayerInitialize({ number, state }),
+      playerInfos: getUpdatedPlayerInit({ number, state }),
     })),
   updatePlayerName: (index: number, updates: PlayerNamesType['name']) =>
     set((state) => ({
-      playerNames: state.playerNames.map((player, i) =>
+      playerInfos: state.playerInfos.map((player, i) =>
         i === index ? { ...player, name: updates } : player,
       ),
     })),
-  updatePlayerColor: (playerId: PlayerNamesType['id'], updates: PlayerNamesType['color']) =>
+  updatePlayerColor: (playerId: PlayerNamesType['id'], updates: PlayerNamesType['playerColor']) =>
     set((state) => ({
-      playerNames: state.playerNames.map((player) =>
+      playerInfos: state.playerInfos.map((player) =>
         playerId === player.id ? { ...player, color: updates } : player,
       ),
     })),
   updateRandomPlayerName: (playerId: PlayerNamesType['id']) =>
     set((state) => {
-      const newPlayers = state.playerNames.map((player) =>
+      const newPlayers = state.playerInfos.map((player) =>
         player.id === playerId ? { ...player, name: generateRandomPlayerName() } : player,
       );
-      return { ...state, playerNames: newPlayers };
+      return { ...state, playerInfos: newPlayers };
     }),
   updateEmptyName: () =>
     set((state) => {
-      const newPlayers = state.playerNames.map((p) =>
+      const newPlayers = state.playerInfos.map((p) =>
         p.name.length === 0 ? { ...p, name: generateRandomPlayerName() } : p,
       );
-      return { ...state, playerNames: newPlayers };
+      return { ...state, playerInfos: newPlayers };
     }),
   updateRandomPlayerColor: (playerId) =>
     set((state) => {
-      const selectedColor = state.playerNames.map((p) => p.color);
-      const availableColor = getAvailableColors(selectedColor);
+      const randomColors = getRandomColors({ number: 1, state });
 
-      const stateWithNewColor = state.playerNames.map((player) =>
-        player.id === playerId ? { ...player, color: getRandomElement(availableColor) } : player,
+      const stateWithNewColor = state.playerInfos.map((player) =>
+        player.id === playerId
+          ? { ...player, playerColor: randomColors?.[0] ?? colorOptions[0].value }
+          : player,
       );
 
-      return { ...state, playerNames: stateWithNewColor };
+      return { ...state, playerInfos: stateWithNewColor };
     }),
 }));
 

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -16,7 +16,8 @@ export interface PlayerState {
   playerNumber: number;
   playerNames: PlayerNamesType[];
   setPlayerNumber: (number: PlayerState['playerNumber']) => void;
-  setPlayerInit: (number: PlayerState['playerNumber']) => void;
+  setPlayerInit: () => void;
+  updatePlayerNumber: (number: PlayerState['playerNumber']) => void;
   updatePlayerName: (index: number, state: PlayerNamesType['name']) => void;
   updateRandomPlayerName: (playerId: PlayerNamesType['id']) => void;
   updateEmptyName: () => void;
@@ -37,7 +38,17 @@ const playerStore = create<PlayerState>((set) => ({
     set(() => ({
       playerNumber: number,
     })),
-  setPlayerInit: (number) =>
+  setPlayerInit: () =>
+    set(() => ({
+      playerNames: Array(2)
+        .fill(null)
+        .map((_, index) => ({
+          id: uuid(),
+          name: '',
+          color: colorOptions[index].value,
+        })),
+    })),
+  updatePlayerNumber: (number) =>
     set((state: PlayerState) => ({
       ...state,
       playerNames: getPlayerInitialize({ number, state }),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,9 +15,10 @@
   - 예: 시작금액 대비 200% 성장 시 100% 계산
  */
 
-const calculateProgress = (turns, properties, assets) => {
+const calculateProgress = (turns: any, properties: any, assets: any) => {
   const turnProgress = (turns / 4) * 0.4; // 바퀴 수 가중치 40%
   const propertyProgress = (properties / 28) * 0.3; // 건물 가중치 30%
+  const startingMoney = 200000;
   const assetProgress = Math.min(assets / startingMoney, 2) * 0.3; // 자산 가중치 30%
 
   return Math.floor((turnProgress + propertyProgress + assetProgress) * 100);
@@ -28,4 +29,14 @@ const getRandomElement = <T>(array: T[]): T => {
   return array[randomIndex];
 };
 
-export { calculateProgress, getRandomElement };
+const updateNestedValue = (obj: any, path: string[], value: any): any => {
+  if (path.length === 0) return value;
+
+  const [first, ...rest] = path;
+  return {
+    ...obj,
+    [first]: updateNestedValue(obj[first] || {}, rest, value),
+  };
+};
+
+export { calculateProgress, getRandomElement, updateNestedValue };


### PR DESCRIPTION
- playerStore / gameStore분리되어있음 

- 생겼던 이슈: 

  - persist로 유지하고 있는 store는 gameStore 
  - playerStore를 업데이트 할 때마다 gameStore에 update 및 DB에 update 로직 필요 
  - playerStore과 gameStore를 동일한 곳에 합치고 싶었으나 복잡도 증가 예상되어 현재상태 유지 결정
  - 업데이트 시마다 syncPlayers호출하여 gameDB에 저장 로직