### PR TITLE
hotfix : playerError

### DIFF
--- a/src/stores/gameLogic.ts
+++ b/src/stores/gameLogic.ts
@@ -103,12 +103,10 @@ const loadGameService = async (
       const store = await connectionManager.getConnection(lastGameName);
       const gameData = await getFromDB<GameData>(lastGameName, store);
 
-      console.log('gameLogic', gameData);
-
       if (gameData) {
         setState({
           ...gameData,
-          createdAt: dayjs(gameData.createdAt),
+          createdAt: gameData.createdAt,
           currentStore: store,
           gameName: lastGameName,
         });
@@ -116,6 +114,7 @@ const loadGameService = async (
       return gameData;
     }
   } catch (error) {
+    console.log('error occured', error);
     if (getState().gameName) {
       await connectionManager.closeConnection(getState().gameName);
     }

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -66,10 +66,20 @@ const gameStore = create<GameState>()(
       },
 
       loadGame: async () => {
-        const result = await loadGameService(setState, getState, { mainStore });
-        landStore.getState().loadGameLands();
-
-        return result;
+        console.log('loadGame called');
+        try {
+          const result = await loadGameService(setState, getState, { mainStore });
+          console.log(result);
+          if (result) {
+            landStore.getState().loadGameLands();
+            playerStore.getState().loadGamePlayers();
+            return result;
+          }
+        } catch (error) {
+          console.error('Failed to load game:', error);
+          getState().resetGame();
+        }
+        return null;
       },
 
       syncPlayers: (players) => {
@@ -88,7 +98,6 @@ const gameStore = create<GameState>()(
         setState((state) => ({
           gameList: state.gameList.filter((gameName) => gameName !== name),
         }));
-        // TODO: 해당 게임의 스토어 삭제 로직 추가
       },
 
       resetGame: () => {

--- a/src/stores/playerLogic.ts
+++ b/src/stores/playerLogic.ts
@@ -73,10 +73,8 @@ const loadGamePlayersService = async (
   try {
     const lastGameName = await getFromDB<string>('currentGame', options.mainStore);
     if (lastGameName) {
-      console.log('loadGamePlayersService lastGameName', lastGameName);
       const store = await createNewStore(lastGameName);
       const gameData = await getFromDB<GameState>(lastGameName, store);
-      console.log(gameData);
 
       if (gameData) {
         setState((state) => ({

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -327,6 +327,6 @@ const playerStore = create<PlayerState>((set, get) => ({
     })),
 }));
 
-playerStore.getState().loadGamePlayers();
+// playerStore.getState().loadGamePlayers();
 
 export default playerStore;


### PR DESCRIPTION
- 새로고침 시 indexedDB에있는 player정보 불러오지 못했던 문제
- DB에서 불러와서 playerStore에 setState할 때의 에러로 try catch문으로 비정상 작동되었었음
- 문제의 이유 : dayjs객체를 dayjs로 감쌌기 때문에 났던 에러(t2.clone is not a function) 
- 디버깅 하기 어려웠던 문제 : catch error를 할 때 return null만을 하고 아무런 안내도 하지 않았음
- 디버깅 용이를 위해 : try catch 문에서의 에러를 캐치할 때는 console등으로 에러문구 표시 필수 
- 고민 : 
    - 실제 배포 화면에서는 ? console은 함부로 하지 말아야한단 말이 있는데 
    - 그렇다면 에러바운더리로 표시 하는 것이 좋을까?
